### PR TITLE
Allow loading of .cjs modules

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -354,7 +354,8 @@ function load(parent?: string, specifier?: string) {
 			switch (Path.extname(name).toLowerCase()) {
 				case '.json':
 					return (module.exports = JSON.parse(asset(id, 'utf-8')));
-				case '.js': {
+				case '.js':
+				case '.cjs': {
 					const dirname = new URL('./', url).toString();
 					const exec = new VM.Script(`(function module(module,exports,require,__dirname,__filename) {\n${asset(id, 'utf-8')}\n})`, { filename: id, lineOffset: -1 }).runInThisContext();
 					const main = modules[resolve().toString()];

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8,6 +8,7 @@ import * as VM from 'node:vm';
 import * as OS from 'node:os';
 import * as FS from 'node:fs';
 import { Module } from 'node:module';
+import assert from 'node:assert';
 
 const VERSION = 1;
 const COMPRESSION = {
@@ -25,7 +26,9 @@ const HASH = {
 const PROTO = 'sea:';
 
 const resolutions: Record<string, Record<string, string>> = JSON.parse(SEA.getAsset('resolv', 'utf8'));
-const blobs = extractBlobs(SEA.getRawAsset('bundle'));
+const bundle = SEA.getRawAsset('bundle');
+assert(typeof bundle === 'object', 'bundle is not an ArrayBuffer');
+const blobs = extractBlobs(bundle);
 
 function extractBlobs(data: ArrayBuffer) {
 	const index: Record<string, ReturnType<typeof blobData>> = {};


### PR DESCRIPTION
I have added an extra switch case to the `load()` function, which means that files with a .cjs extension are handled in the same way as .js.

I have also fixed a TypeScript error at `runtime.ts:29`:
```
Argument of type 'string | ArrayBuffer' is not assignable to parameter of type 'ArrayBuffer'.
  Type 'string' is not assignable to type 'ArrayBuffer'.
```

I have `assert`ed that the bundle raw asset is an object and therefore must be an ArrayBuffer in TypeScript.